### PR TITLE
Fixed coupon code apply

### DIFF
--- a/Plugin/Quote/Model/CouponManagementPlugin.php
+++ b/Plugin/Quote/Model/CouponManagementPlugin.php
@@ -27,6 +27,6 @@ class CouponManagementPlugin
         if (substr($couponCode, 0, 3) === 'KS_') {
             throw new \Exception(__("The coupon code isn't valid. Verify the code and try again."));
         }
-        return $proceed();
+        return $proceed($cartId, $couponCode);
     }
 }


### PR DESCRIPTION
Fixes error: Too few arguments to function Magento\Quote\Model\CouponManagement::set(), 0 passed in /var/www/html/vendor/magento/framework/Interception/Interceptor.php on line 58 and exactly 2 expected